### PR TITLE
simplify usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,25 +51,13 @@ Make Excavator available from the network:
 ------
  - If you are using the Nicehash Quick Miner:
    - Right-click the icon in the icon tray -> Settings -> Edit config file
-   - Search "watchDogAPIHost" and set the value to "127.0.0.1"
-   - Search "watchDogAPIPort" and remember the value (default is 18000)
+   - Search "watchDogAPIHost" and set the value to "your_mining_pc_ip_v4"
+   - Search "watchDogAPIPort" and remember the value (default is 18000) or change to another unused_port_of_your_choise
    - Save and close the config file
-   - Open the command prompt and paste the following command with your desired entries:
-     - netsh interface portproxy add v4tov4 listenaddress=your_mining_pc_ip_v4 listenport=unused_port_of_your_choise connectaddress=127.0.0.1 connectport=your_watchDogAPIPort
-     - Example: netsh interface portproxy add v4tov4 listenaddress=192.168.0.10 listenport=18001 connectaddress=127.0.0.1 connectport=18000
-     - (this will create a port forwarding from the network to your excavator instance which is only locally available)
-   - Create an inbound firewall rule allowing the unused_port_of_your_choise to be accessed
+   - Create an inbound firewall rule allowing the previusly used port (watchDogAPIPort) to be accessed
    - You should now be able to access the Excavator API via your network
  - If you are running Excavator directly from the command line:
    - Add the command line arguments -wi your_mining_pc_ip_v4 and -wp unused_port_of_your_choise
      - Doku: https://github.com/nicehash/excavator#-command-line-parameters
    - Create an inbound firewall rule allowing the unused_port_of_your_choise to be accessed
    - You should now be able to access the Excavator API via your network
-
-
-Misc:
-------
- - Remove proxy needed for Quick Miner:
-   - netsh interface portproxy delete v4tov4 listenport=unused_port_of_your_choise listenaddress=your_mining_pc_ip_v4
- - Show all active proxies:
-   - netsh interface portproxy show all


### PR DESCRIPTION
for some reason each time after win pc restart my port forwarding rules didn't work, so I used much simpler configuration without need for port-forwarding
only down-side may be that locally it is no more accessible via localhost or 127.0.0.1, but it is still accessible via local ipv4 address